### PR TITLE
feat/22-테일윈드 spacing 단위 설정

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -43,4 +43,5 @@
   --text-caption1--line-height: 1.125rem;
   --breakpoint-tablet: 48rem;
   --breakpoint-pc: 75rem;
+  --spacing: 0.0625rem;
 }


### PR DESCRIPTION
## 📝 PR 내용 요약

> 어떤 작업을 했는지 간단히 요약해주세요.

- 기본 테일윈드의 spacing의 기본값이 0.25rem이라 margin 16px을 나타내려면 m-4 나 m-[16px]로 사용했었습니다.
- 기본값을 0.0625rem으로 수정해서 margin 16px을 m-16으로 사용하면 좋을 거 같습니다.
- spacing값이 사용되는 테일윈드 속성들입니다. 기존에 사용했다면 수정이 필요합니다.
 
유틸리티 | 예시
-- | --
Margin | m-4, mt-8
Padding | p-2, px-6
Gap | gap-4
Space Between | space-x-2
Width/Height | w-64, h-32
Position | top-4, inset-6
Transform | translate-y-3
Scroll Margin | scroll-mt-16


---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #22

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.

(이미지 첨부)

---
