### PR TITLE
🔧 [fix] Pretendard 웹폰트 적용

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,9 @@
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css");
 @import "tailwindcss";
 
 @layer base {
   html {
-    font-family: "Pretendard", sans-serif;
+    font-family: Pretendard, sans-serif;
   }
 }
 


### PR DESCRIPTION
## 📝 PR 내용 요약

> Pretendard 웹폰트를 import 시켜 적용시켰습니다.
> font-weight 500과 400의 차이가 없었던 이유는 글꼴이 Pretendard가 아니라 sans-serif 였기 때문
> + Pretendard는 기본 글꼴이 아니기 때문에(환경에 따라 있을 수도 없을 수도 있음) 별도로 import 해줘야 합니다

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)
- Close #30 

## 📸 스크린샷 (선택)

> 좌측부터 Sans-serif regular, Pretendard regular, Pretendard medium, Pretendard Bold
![스크린샷 2025-04-17 164144](https://github.com/user-attachments/assets/bcc4c635-1df7-479b-918f-79b0b0fbe2ec)

> 적용 전
![스크린샷 2025-04-17 165321](https://github.com/user-attachments/assets/ab49d5c7-2c8f-4b6d-9265-4e7bbbb1fb1c)

> 적용 후
![스크린샷 2025-04-17 165247](https://github.com/user-attachments/assets/507aa447-b9bb-44c5-815d-e88c417e0aed)

