### PR TITLE
Feat/11-질문 박스 컴포넌트화

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -22,9 +22,9 @@
   --color-blue-50: #1877f2;
   --color-yellow-50: #fee500;
   --color-red-50: #b93333;
-  --shadow-1px: 0px 4px 4px 0px rgba(140, 140, 140, 0.25);
-  --shadow-2px: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
-  --shadow-3px: 0px 16px 20px 0px rgba(48, 48, 48, 0.62);
+  --shadow-1pt: 0px 4px 4px 0px rgba(140, 140, 140, 0.25);
+  --shadow-2pt: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+  --shadow-3pt: 0px 16px 20px 0px rgba(48, 48, 48, 0.62);
   --font-weight-regular: 400;
   --font-weight-medium: 500;
   --font-weight-bold: 700;

--- a/src/components/QuestionBox.jsx
+++ b/src/components/QuestionBox.jsx
@@ -1,0 +1,26 @@
+import MessageIcon from "../assets/icons/messages.svg";
+import EmptyBox from "../assets/images/empty-box.svg";
+
+const QuestionBox = ({ children, count }) => {
+  const text = count ? `${count}개의 질문이 있습니다.` : "아직 질문이 없습니다";
+  return (
+    <div className="border-brown-20 bg-brown-10 tablet:px-32 mt-54 flex min-h-330 w-full max-w-716 flex-col items-center rounded-2xl border px-24 py-16">
+      <div className="flex gap-8">
+        <img
+          className="tablet:size-24 size-22"
+          src={MessageIcon}
+          alt="메시지 아이콘"
+        />
+        <p className="text-body2 tablet:text-body1 text-brown-40 font-regular">
+          {text}
+        </p>
+      </div>
+      {count ? (
+        children
+      ) : (
+        <img className="mt-66 w-114" src={EmptyBox} alt="빈 박스 이미지" />
+      )}
+    </div>
+  );
+};
+export default QuestionBox;


### PR DESCRIPTION
## 📝 PR 내용 요약

> 어떤 작업을 했는지 간단히 요약해주세요.

- 질문리스트가 들어갈 질문 박스를 컴포넌트로 만들었습니다.
- children을 통해 박스안에 내용을 넣어주고 count를 통해 질문의 개수를 주어 count가 0일때는 빈 박스 아이콘을 보여줍니다.
- 추가적으로 피그마에 shadow 1pt라 되어있는걸 잘못 봐서 1px로 해 두었길래 테일윈드 수정했습니다. 혹시나 그림자를 사용하셨다면 죄송합니다. pt로 수정 부탁드립니다.
- 메시지 아이콘을 svg 컴포넌트로 제작하면 변경하겠습니다.

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #11

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.

(이미지 첨부)

---
