### PR TITLE
Feat/53 무한스크롤 구현

### DIFF
--- a/src/components/QuestionLayout.jsx
+++ b/src/components/QuestionLayout.jsx
@@ -1,7 +1,8 @@
 import { Link, Outlet, useLocation, useParams } from "react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { getQuestionList } from "../api/subjects";
 import useSubject from "../hooks/useSubject";
+import useInfiniteScroll from "../hooks/useInfiniteScroll";
 import LogoImg from "../assets/images/logo.png";
 
 const QuestionLayout = () => {
@@ -15,7 +16,6 @@ const QuestionLayout = () => {
   const [offset, setOffset] = useState(0);
   const [isMoreQuestion, setIsMoreQuestion] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const ref = useRef(null);
 
   useEffect(() => {
     if (!questionCount) return;
@@ -42,24 +42,7 @@ const QuestionLayout = () => {
     }
     setIsLoading(false);
   }, [id, offset, questionCount, isLoading]);
-  useEffect(() => {
-    if (!ref.current || !isMoreQuestion) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting) {
-          getMoreData();
-        }
-      },
-      { threshold: 0.1 },
-    );
-
-    observer.observe(ref.current);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [isMoreQuestion, isLoading, offset, getMoreData, id, questionCount]);
+  const { ref } = useInfiniteScroll({ callback: getMoreData, isMoreQuestion });
 
   return (
     <div className="bg-grayscale-20 relative min-h-screen pb-126">

--- a/src/components/QuestionLayout.jsx
+++ b/src/components/QuestionLayout.jsx
@@ -27,11 +27,11 @@ const QuestionLayout = () => {
     }
   }, [name, id]);
   useEffect(() => {
-    const getData = async () => {
+    const getInitialData = async () => {
       const { results } = await getQuestionList({ subjectId: id });
-      setQuestionList((prev) => [...prev, ...results]);
+      setQuestionList(results);
     };
-    getData();
+    getInitialData();
   }, [id]);
   return (
     <div className="bg-grayscale-20 relative min-h-screen pb-126">

--- a/src/components/QuestionLayout.jsx
+++ b/src/components/QuestionLayout.jsx
@@ -1,34 +1,22 @@
 import { Link, Outlet, useLocation, useParams } from "react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { getQuestionList, getSubject } from "../api/subjects";
+import { getQuestionList } from "../api/subjects";
+import useSubject from "../hooks/useSubject";
 import LogoImg from "../assets/images/logo.png";
 
 const QuestionLayout = () => {
   const [questionList, setQuestionList] = useState([]);
   const { id } = useParams();
   const location = useLocation();
-  const [name, setName] = useState(location.state?.name);
-  const [imageSource, setImageSource] = useState(location.state?.imageSource);
-  const [questionCount, setQuestionCount] = useState(
-    location.state?.questionCount,
-  );
+  const { name, imageSource, questionCount } = useSubject({
+    id,
+    subject: location.state,
+  });
   const [offset, setOffset] = useState(0);
   const [isMoreQuestion, setIsMoreQuestion] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const ref = useRef(null);
-  useEffect(() => {
-    if (!name) {
-      const getSubjectData = async () => {
-        const { name, imageSource, questionCount } = await getSubject({
-          subjectId: id,
-        });
-        setName(name);
-        setImageSource(imageSource);
-        setQuestionCount(questionCount);
-      };
-      getSubjectData();
-    }
-  }, [name, id]);
+
   useEffect(() => {
     const getInitialData = async () => {
       setIsLoading(true);

--- a/src/components/QuestionLayout.jsx
+++ b/src/components/QuestionLayout.jsx
@@ -18,6 +18,7 @@ const QuestionLayout = () => {
   const ref = useRef(null);
 
   useEffect(() => {
+    if (!questionCount) return;
     const getInitialData = async () => {
       setIsLoading(true);
       const { results } = await getQuestionList({ subjectId: id });

--- a/src/hooks/useInfiniteScroll.js
+++ b/src/hooks/useInfiniteScroll.js
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from "react";
+
+const useInfiniteScroll = ({ callback, isMoreQuestion }) => {
+  const ref = useRef(null);
+  useEffect(() => {
+    if (!ref.current || !isMoreQuestion) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          callback();
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(ref.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [isMoreQuestion, callback]);
+  return { ref };
+};
+export default useInfiniteScroll;

--- a/src/hooks/useInitialQuestion.js
+++ b/src/hooks/useInitialQuestion.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { getQuestionList } from "../api/subjects";
+import { getQuestionList } from "../api/questions";
 
 const useInitialQuestion = ({
   id,

--- a/src/hooks/useInitialQuestion.js
+++ b/src/hooks/useInitialQuestion.js
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { getQuestionList } from "../api/subjects";
+
+const useInitialQuestion = ({
+  id,
+  questionCount,
+  setQuestionList,
+  setOffset,
+  setIsMoreQuestion,
+}) => {
+  const [isInitialLoading, setIsInitialLoading] = useState(false);
+  useEffect(() => {
+    if (!questionCount) return;
+    const getInitialData = async () => {
+      setIsInitialLoading(true);
+      const { results } = await getQuestionList({ subjectId: id });
+      setQuestionList(results);
+      setOffset(results.length);
+      if (results.length < questionCount) {
+        setIsMoreQuestion(true);
+      }
+      setIsInitialLoading(false);
+    };
+    getInitialData();
+  }, [id, questionCount, setQuestionList, setOffset, setIsMoreQuestion]);
+  return { isInitialLoading };
+};
+export default useInitialQuestion;

--- a/src/hooks/useSubject.js
+++ b/src/hooks/useSubject.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { getSubject } from "../api/subjects";
+
+const useSubject = ({ id, subject }) => {
+  const [name, setName] = useState(subject?.name);
+  const [imageSource, setImageSource] = useState(subject?.imageSource);
+  const [questionCount, setQuestionCount] = useState(subject?.questionCount);
+  const [isSubject, setIsSubject] = useState(!!subject);
+  useEffect(() => {
+    if (!subject) {
+      const getSubjectData = async () => {
+        const { name, imageSource, questionCount } = await getSubject({
+          subjectId: id,
+        });
+        setName(name);
+        setImageSource(imageSource);
+        setQuestionCount(questionCount);
+        setIsSubject(true);
+      };
+      getSubjectData();
+    }
+  }, [subject, id]);
+  return { name, imageSource, questionCount, isSubject };
+};
+export default useSubject;

--- a/src/hooks/useSubject.js
+++ b/src/hooks/useSubject.js
@@ -2,24 +2,28 @@ import { useEffect, useState } from "react";
 import { getSubject } from "../api/subjects";
 
 const useSubject = ({ id, subject }) => {
-  const [name, setName] = useState(subject?.name);
-  const [imageSource, setImageSource] = useState(subject?.imageSource);
-  const [questionCount, setQuestionCount] = useState(subject?.questionCount);
-  const [isSubject, setIsSubject] = useState(!!subject);
+  const [subjectData, setSubjectData] = useState({
+    name: subject?.name,
+    imageSource: subject?.imageSource,
+    questionCount: subject?.questionCount,
+    isSubject: !!subject,
+  });
   useEffect(() => {
     if (!subject) {
       const getSubjectData = async () => {
         const { name, imageSource, questionCount } = await getSubject({
           subjectId: id,
         });
-        setName(name);
-        setImageSource(imageSource);
-        setQuestionCount(questionCount);
-        setIsSubject(true);
+        setSubjectData({
+          name,
+          imageSource,
+          questionCount,
+          isSubject: true,
+        });
       };
       getSubjectData();
     }
   }, [subject, id]);
-  return { name, imageSource, questionCount, isSubject };
+  return subjectData;
 };
 export default useSubject;


### PR DESCRIPTION
## 📝 PR 내용 요약

> 어떤 작업을 했는지 간단히 요약해주세요.

- 데이터를 2번 불러오는 현상을 수정했습니다.
- 무한 스크롤을 구현 했습니다.
- subject관련 정보(이름, 프로필이미지,질문개수)를 처리하는 부분을 훅으로 분리했습니다. 
- 초기 질문을 받아오는 부분을 훅으로 분리했습니다.
- 무한 스크롤을 훅으로 분리했습니다.
- 머지가 되면 QuestionLayout의 이름을 QuestionContainer로 바꾸고 디자인을 제외한 부분을 페이지로 넘긴 뒤 컴포넌트처럼 사용하게 수정하겠습니다. 

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #53 
- Close #77

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.

(이미지 첨부)

---
