### PR TITLE
[Feat]listpage 페이지네이션 구현

### DIFF
--- a/src/components/Pagenation.jsx
+++ b/src/components/Pagenation.jsx
@@ -7,17 +7,24 @@ function Pagenation({ totalPages, currentPage, onPageChange }) {
     onPageChange(page);
   };
 
+  const range = 5;
+  let startPage = Math.max(currentPage - Math.floor(range / 2), 1);
+  let endPage = Math.min(startPage + range - 1, totalPages);
+  if (endPage - startPage + 1 < range) {
+    startPage = Math.max(endPage - range + 1, 1);
+  }
+
   return (
     <ul className="text-body1 weight-regular text-grayscale-40 flex items-center justify-center pt-40">
       <ArrowLeft
         className="cursor-pointer"
         onClick={() => movePage(currentPage - 1)}
       />
-      {[...Array(totalPages)].map((value, index) => {
-        const page = index + 1;
+      {[...Array(endPage - startPage + 1)].map((value, index) => {
+        const page = startPage + index;
         return (
           <li
-            className={`${page === currentPage ? "text-brown-40" : ""} flex size-40 cursor-pointer items-center justify-center`}
+            className={`${page === currentPage ? "text-brown-40" : ""} hover:text-grayscale-60 flex size-40 cursor-pointer items-center justify-center`}
             key={index}
             onClick={() => movePage(page)}
           >

--- a/src/components/Pagenation.jsx
+++ b/src/components/Pagenation.jsx
@@ -17,7 +17,7 @@ function Pagenation({ totalPages, currentPage, onPageChange }) {
         const page = index + 1;
         return (
           <li
-            className={`${page === currentPage && "text-brown-40"} flex size-40 cursor-pointer items-center justify-center`}
+            className={`${page === currentPage ? "text-brown-40" : ""} flex size-40 cursor-pointer items-center justify-center`}
             key={index}
             onClick={() => movePage(page)}
           >

--- a/src/components/Pagenation.jsx
+++ b/src/components/Pagenation.jsx
@@ -1,16 +1,10 @@
-import { useState } from "react";
 import ArrowLeft from "../assets/icons/arrow-left.svg?react";
 import ArrowRight from "../assets/icons/arrow-right.svg?react";
 
-function Pagenation() {
-  const totalUsers = 32;
-  const itemsPerPage = 6;
-  const totalPages = Math.ceil(totalUsers / itemsPerPage);
-  const [currentPage, setcurrentPage] = useState(1);
-
+function Pagenation({ totalPages, currentPage, onPageChange }) {
   const movePage = (page) => {
     if (page < 1 || page > totalPages) return;
-    setcurrentPage(page);
+    onPageChange(page);
   };
 
   return (

--- a/src/components/Pagenation.jsx
+++ b/src/components/Pagenation.jsx
@@ -17,8 +17,9 @@ function Pagenation({ totalPages, currentPage, onPageChange }) {
         const page = index + 1;
         return (
           <li
-            className={`${page === currentPage && "text-brown-40"} flex size-40 items-center justify-center`}
+            className={`${page === currentPage && "text-brown-40"} flex size-40 cursor-pointer items-center justify-center`}
             key={index}
+            onClick={() => movePage(page)}
           >
             {page}
           </li>

--- a/src/components/Pagenation.jsx
+++ b/src/components/Pagenation.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import ArrowLeft from "../assets/icons/arrow-left.svg?react";
 import ArrowRight from "../assets/icons/arrow-right.svg?react";
 
@@ -5,11 +6,19 @@ function Pagenation() {
   const totalUsers = 32;
   const itemsPerPage = 6;
   const totalPages = Math.ceil(totalUsers / itemsPerPage);
-  const currentPage = 1;
+  const [currentPage, setcurrentPage] = useState(1);
+
+  const movePage = (page) => {
+    if (page < 1 || page > totalPages) return;
+    setcurrentPage(page);
+  };
 
   return (
     <ul className="text-body1 weight-regular text-grayscale-40 flex items-center justify-center pt-40">
-      <ArrowLeft className="cursor-pointer" />
+      <ArrowLeft
+        className="cursor-pointer"
+        onClick={() => movePage(currentPage - 1)}
+      />
       {[...Array(totalPages)].map((value, index) => {
         const page = index + 1;
         return (
@@ -21,7 +30,10 @@ function Pagenation() {
           </li>
         );
       })}
-      <ArrowRight className="cursor-pointer" />
+      <ArrowRight
+        className="cursor-pointer"
+        onClick={() => movePage(currentPage + 1)}
+      />
     </ul>
   );
 }

--- a/src/components/Pagenation.jsx
+++ b/src/components/Pagenation.jsx
@@ -1,0 +1,29 @@
+import ArrowLeft from "../assets/icons/arrow-left.svg?react";
+import ArrowRight from "../assets/icons/arrow-right.svg?react";
+
+function Pagenation() {
+  const totalUsers = 32;
+  const itemsPerPage = 6;
+  const totalPages = Math.ceil(totalUsers / itemsPerPage);
+  const currentPage = 1;
+
+  return (
+    <ul className="text-body1 weight-regular text-grayscale-40 flex items-center justify-center pt-40">
+      <ArrowLeft className="cursor-pointer" />
+      {[...Array(totalPages)].map((value, index) => {
+        const page = index + 1;
+        return (
+          <li
+            className={`${page === currentPage && "text-brown-40"} flex size-40 items-center justify-center`}
+            key={index}
+          >
+            {page}
+          </li>
+        );
+      })}
+      <ArrowRight className="cursor-pointer" />
+    </ul>
+  );
+}
+
+export default Pagenation;

--- a/src/components/UserList.jsx
+++ b/src/components/UserList.jsx
@@ -2,7 +2,7 @@ import UserCard from "./UserCard";
 
 function UserList({ users }) {
   return (
-    <ul className="tablet:grid-cols-[repeat(auto-fill,_minmax(186px,1fr))] pc:grid-cols-4 grid w-full max-w-940 grid-cols-2 justify-center gap-16">
+    <ul className="tablet:grid-cols-[repeat(auto-fill,_minmax(186px,1fr))] pc:grid-cols-4 grid w-full max-w-928 grid-cols-2 justify-center gap-16">
       {users.map((user) => {
         const { imageSource, name, questionCount } = user;
 

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -16,8 +16,14 @@ function ListPage() {
   const [totalPages, setTotalPages] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(4);
   const [currentPage, setCurrentPage] = useState(1);
-  const handleLatestClick = () => setSort("createdAt");
-  const handleNameClick = () => setSort("name");
+  const handleLatestClick = () => {
+    setSort("createdAt");
+    setCurrentPage(1);
+  };
+  const handleNameClick = () => {
+    setSort("name");
+    setCurrentPage(1);
+  };
 
   const options = [
     { label: "최신순", value: "createdAt", click: handleLatestClick },

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -47,27 +47,24 @@ function ListPage() {
     window.innerWidth > 891 ? setItemsPerPage(8) : setItemsPerPage(6);
   }, []);
 
-  const getUser = useCallback(async () => {
-    const offset = (currentPage - 1) * itemsPerPage;
-    const user = await getUserList({ limit: 8, offset, sort });
-    setUsers(user.data.results);
-    setTotalUsers(user.data.count);
-    setTotalPages(Math.ceil(totalUsers / itemsPerPage));
+  useEffect(() => {
+    const getUser = async () => {
+      const offset = (currentPage - 1) * itemsPerPage;
+      const user = await getUserList({ limit: 8, offset, sort });
+      setUsers(user.data.results);
+      setTotalUsers(user.data.count);
+      setTotalPages(Math.ceil(totalUsers / itemsPerPage));
+    };
+    getUser();
   }, [totalUsers, itemsPerPage, currentPage, sort]);
 
   useEffect(() => {
-    getUser();
-  }, [getUser]);
-
-  useEffect(() => {
     handleResize();
-
     window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
   }, [handleResize]);
 
   return (
-    <div className="bg-grayscale-2 h-screen">
+    <div className="bg-grayscale-20 h-screen">
       <div className="tablet:flex-row tablet:justify-between flex flex-col items-center justify-center gap-24 px-50 pt-40 pb-60">
         <Link to="/">
           <img className="h-57 w-146" src={logo}></img>

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
 import { getUserList } from "../api/subjects";
 import logo from "../assets/images/logo.png";
 import Arrow from "../assets/icons/arrow.svg?react";
 import Button from "../components/Button";
 import UserList from "../components/UserList";
-import { useNavigate } from "react-router";
 import DropdownTrigger from "../components/DropdownTrigger";
+import Pagenation from "../components/Pagenation";
 
 function ListPage() {
   const navigate = useNavigate();
@@ -65,8 +65,7 @@ function ListPage() {
           <UserList users={users} />
         </div>
       </div>
-      {/* Pagenation 컴포넌트로 수정 예정*/}
-      <div className="flex items-center justify-center">1 2 3 4 5</div>
+      <Pagenation />
     </div>
   );
 }

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -49,7 +49,7 @@ function ListPage() {
 
   const getUser = useCallback(async () => {
     const offset = (currentPage - 1) * itemsPerPage;
-    const user = await getUserList({ limit: itemsPerPage, offset, sort });
+    const user = await getUserList({ limit: 8, offset, sort });
     setUsers(user.data.results);
     setTotalUsers(user.data.count);
     setTotalPages(Math.ceil(totalUsers / itemsPerPage));
@@ -85,7 +85,7 @@ function ListPage() {
           <DropdownTrigger options={options} type="user" />
         </div>
         <div className="tablet:gap-20 flex flex-wrap items-center justify-center gap-16">
-          <UserList users={users} />
+          <UserList users={users.slice(0, itemsPerPage)} />
         </div>
       </div>
       <Pagenation

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -40,7 +40,7 @@ function ListPage() {
   }, []);
 
   useEffect(() => {
-    getUser({ limit: 6, offset: 0, sort });
+    getUser({ limit: 10, offset: 0, sort });
   }, [getUser, sort]);
 
   return (

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -14,7 +14,7 @@ function ListPage() {
   const [sort, setSort] = useState("createdAt");
   const [totalUsers, setTotalUsers] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
-  const [itemsPerPage, setItemsPerPage] = useState(4);
+  const [itemsPerPage, setItemsPerPage] = useState(1);
   const [currentPage, setCurrentPage] = useState(1);
   const handleLatestClick = () => {
     setSort("createdAt");
@@ -67,7 +67,7 @@ function ListPage() {
   }, [handleResize]);
 
   return (
-    <div className="bg-grayscale-20">
+    <div className="bg-grayscale-2 h-screen">
       <div className="tablet:flex-row tablet:justify-between flex flex-col items-center justify-center gap-24 px-50 pt-40 pb-60">
         <Link to="/">
           <img className="h-57 w-146" src={logo}></img>


### PR DESCRIPTION
## 📝 PR 내용 요약

> 어떤 작업을 했는지 간단히 요약해주세요.

- listpage 페이지네이션 구현
- 화살표 누르면 페이지 앞, 뒤로 이동
- 페이지 번호 누르면 해당 페이지로 이동
- 최신순, 이름순으로 정렬하면 첫 번째 페이지로 자동 이동
- 페이지 번호는 고정으로 5개만 보여주기
- 6개->8개로 카드 갯수 변경될 때 부자연스러운 부분 개선 완료

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #61

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/51efb5ba-dd01-4a4b-a053-d26708f02684" />

---
