### PR TITLE
Bug/109 새로고침 시 questioncount 문제

### DIFF
--- a/src/components/UserList.jsx
+++ b/src/components/UserList.jsx
@@ -5,7 +5,7 @@ function UserList({ users }) {
   const navigate = useNavigate();
 
   const handleCardClick = (user) => {
-    navigate(`/post/${user.id}`, { state: user });
+    navigate(`/post/${user.id}`);
     console.log(user);
   };
 

--- a/src/hooks/useSubject.js
+++ b/src/hooks/useSubject.js
@@ -1,29 +1,27 @@
 import { useEffect, useState } from "react";
 import { getSubject } from "../api/subjects";
 
-const useSubject = ({ id, subject }) => {
-  const [subjectData, setSubjectData] = useState({
-    name: subject?.name,
-    imageSource: subject?.imageSource,
-    questionCount: subject?.questionCount,
-    isSubject: !!subject,
+const useSubject = (id) => {
+  const [subject, setSubject] = useState({
+    name: "",
+    imageSource: "",
+    isSubject: false,
   });
+  const [questionCount, setQuestionCount] = useState(0);
   useEffect(() => {
-    if (!subject) {
-      const getSubjectData = async () => {
-        const { name, imageSource, questionCount } = await getSubject({
-          subjectId: id,
-        });
-        setSubjectData({
-          name,
-          imageSource,
-          questionCount,
-          isSubject: true,
-        });
-      };
-      getSubjectData();
-    }
-  }, [subject, id]);
-  return subjectData;
+    const getSubjectData = async () => {
+      const { name, imageSource, questionCount } = await getSubject({
+        subjectId: id,
+      });
+      setSubject({
+        name,
+        imageSource,
+        isSubject: true,
+      });
+      setQuestionCount(questionCount);
+    };
+    getSubjectData();
+  }, [id]);
+  return { subject, questionCount, setQuestionCount };
 };
 export default useSubject;

--- a/src/pages/AnswerPage.jsx
+++ b/src/pages/AnswerPage.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { useLocation, useNavigate, useParams } from "react-router";
+import { useNavigate, useParams } from "react-router";
 import QuestionBox from "../components/QuestionBox";
 import FeedCard from "../components/FeedCard";
 import { deleteSubject } from "../api/subjects";
@@ -13,18 +13,12 @@ import QuestionContainer from "../components/QuestionContainer";
 const AnswerPage = () => {
   const [questionList, setQuestionList] = useState([]);
   const { id } = useParams();
-  const location = useLocation();
   const [offset, setOffset] = useState(0);
   const [isMoreQuestion, setIsMoreQuestion] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const navigate = useNavigate();
-
-  const { name, imageSource, questionCount } = useSubject({
-    id,
-    subject: location.state,
-  });
-  const subject = { name, imageSource };
+  const { subject, questionCount } = useSubject(id);
 
   const { isInitialLoading } = useInitialQuestion({
     id,

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -37,10 +37,7 @@ function ListPage() {
       return;
     }
     const { id } = JSON.parse(data);
-    const selectedUser = users.find((user) => user.id === id);
-    id
-      ? navigate(`/post/${id}/answer`, { state: { selectedUser } })
-      : navigate("/");
+    id ? navigate(`/post/${id}/answer`) : navigate("/");
   };
 
   const handleResize = useCallback(() => {

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -24,13 +24,7 @@ const MainPage = () => {
       );
       console.log(localStorage);
 
-      navigate(`/post/${subjectId}`, {
-        state: {
-          name: response.name,
-          questionCount: response.questionCount,
-          imageSource: response.imageSource,
-        },
-      });
+      navigate(`/post/${subjectId}`);
     } catch (error) {
       console.error("이름 등록 실패:", error);
     }

--- a/src/pages/QuestionPage.jsx
+++ b/src/pages/QuestionPage.jsx
@@ -1,27 +1,21 @@
 import { useCallback, useState } from "react";
-import { useLocation, useParams } from "react-router";
+import { useParams } from "react-router";
 import QuestionBox from "../components/QuestionBox";
 import FeedCard from "../components/FeedCard";
 import QuestionButton from "../components/QuestionButton";
+import QuestionContainer from "../components/QuestionContainer";
 import useSubject from "../hooks/useSubject";
 import useInitialQuestion from "../hooks/useInitialQuestion";
 import useInfiniteScroll from "../hooks/useInfiniteScroll";
 import { getQuestionList } from "../api/questions";
-import QuestionContainer from "../components/QuestionContainer";
 
 const QuestionPage = () => {
   const [questionList, setQuestionList] = useState([]);
   const { id } = useParams();
-  const location = useLocation();
   const [offset, setOffset] = useState(0);
   const [isMoreQuestion, setIsMoreQuestion] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-
-  const { name, imageSource, questionCount } = useSubject({
-    id,
-    subject: location.state,
-  });
-  const subject = { name, imageSource };
+  const { subject, questionCount, setQuestionCount } = useSubject(id);
 
   const { isInitialLoading } = useInitialQuestion({
     id,


### PR DESCRIPTION
## 📝 PR 내용 요약

> 어떤 작업을 했는지 간단히 요약해주세요.

- 질문을 작성하게 되면 questionCount가 1씩 증가합니다. questionCount가 올라가지만 새로고침을 하면 location의 questionCount를 받아오게 됩니다. location으로 받아오는 questionCount의 값은 질문 작성으로 늘어난 갯수가 아니기 때문에 questionCount는 항상 서버에서 데이터를 받아와야 할 거 같습니다. questionCount만 받아오는 Api가 없고 유저의 이름과 사진을 포함하고 있기 때문에 location으로 유저 데이터를 받아오는 작업이 의미가 없을 거 같습니다. 
- state를 받지 않고 유저 정보를 받아오도록 코드를 수정했습니다.
- 질문 작성 시 count가 올라야 하므로 count를 subject에서 개별적인 상태로 분리했습니다.
- state를 보내주는 부분을 제거했습니다.

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #109

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.

(이미지 첨부)

---
