### PR TITLE
feat/64 카카오 버튼 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,13 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script
+      src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.5/kakao.min.js"
+      integrity="sha384-dok87au0gKqJdxs7msEdBPNnKSRT+/mhTVzq+qOhcL464zXwvcrpjeWvyj1kCdq6"
+      crossorigin="anonymous"
+    ></script>
     <title>4U</title>
   </head>
   <body>

--- a/src/components/KakaoShareButton.jsx
+++ b/src/components/KakaoShareButton.jsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import Kakao from "../assets/icons/kakaotalk.svg?react";
+
+const KakaoShareButton = () => {
+  useEffect(() => {
+    if (window.Kakao && !window.Kakao.isInitialized()) {
+      window.Kakao.init(import.meta.env.VITE_API_KAKAO_JAVASCRIPT);
+    }
+  });
+  const shareToKakao = () => {
+    window.Kakao.Share.sendScrap({
+      requestUrl: window.location.href,
+    });
+  };
+  return (
+    <button
+      className="flex size-40 cursor-pointer items-center justify-center rounded-full bg-yellow-50"
+      onClick={shareToKakao}
+    >
+      <Kakao className="size-18 text-black" />
+    </button>
+  );
+};
+export default KakaoShareButton;

--- a/src/components/QuestionContainer.jsx
+++ b/src/components/QuestionContainer.jsx
@@ -2,6 +2,7 @@ import { Link } from "react-router";
 import LogoImg from "../assets/images/logo.png";
 import UrlShareButton from "./UrlShareButton";
 import FacebookShareButton from "./FacebookShareButton";
+import KakaoShareButton from "./KakaoShareButton";
 
 const QuestionContainer = ({ children, subject }) => {
   return (
@@ -25,7 +26,9 @@ const QuestionContainer = ({ children, subject }) => {
             <li>
               <UrlShareButton />
             </li>
-            <li className="size-40 rounded-full bg-yellow-50"></li>
+            <li>
+              <KakaoShareButton />
+            </li>
             <li>
               <FacebookShareButton />
             </li>


### PR DESCRIPTION
## 📝 PR 내용 요약

> 어떤 작업을 했는지 간단히 요약해주세요.

- 카카오 공유 버튼을 구현했습니다
- 아직 메타태그를 설정해주지 않아서 빈 이미지와 빈 내용이 보내집니다. 메타태그를 설정 한 뒤 다시 테스트를 해봐야 할 거 같습니다.
- 자세히보기 버튼을 누르면 공유한 페이지로 이동은 잘 됩니다.
- 현재는 메타태그를 기반으로 하는 스크랩 공유 방식으로 해주었는데 직접 공유하는 내용을 정하는 방법으로도 수정이 가능합니다.

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #64

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
![화면 캡처 2025-04-25 173619](https://github.com/user-attachments/assets/29ce32ca-c799-4bd2-8667-3daf88d5d6e7)
![화면 캡처 2025-04-25 173638](https://github.com/user-attachments/assets/a7cd170b-ff41-4223-86df-804fc186f861)

(이미지 첨부)

---
