### PR TITLE
Bug/122 스크롤이 내려간 상태로 다른 페이지로 이동하면 스크롤이 유지됩니다

### DIFF
--- a/src/pages/AnswerPage.jsx
+++ b/src/pages/AnswerPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { deleteSubject } from "../api/subjects";
 import { getQuestionList } from "../api/questions";
@@ -55,6 +55,9 @@ const AnswerPage = () => {
       setIsDeleting(false);
     }
   };
+
+  useEffect(() => window.scrollTo(0, 0), []);
+
   return (
     <QuestionContainer subject={subject}>
       <div className="relative w-full max-w-716">

--- a/src/pages/QuestionPage.jsx
+++ b/src/pages/QuestionPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router";
 import { getQuestionList } from "../api/questions";
 import QuestionBox from "../components/QuestionBox";
@@ -38,6 +38,9 @@ const QuestionPage = () => {
   }, [id, offset, questionCount, isLoading, isInitialLoading]);
 
   const { ref } = useInfiniteScroll({ callback: getMoreData, isMoreQuestion });
+
+  useEffect(() => window.scrollTo(0, 0), []);
+
   return (
     <QuestionContainer subject={subject}>
       <QuestionBox count={questionCount}>


### PR DESCRIPTION
## 📝 PR 내용 요약

> 어떤 작업을 했는지 간단히 요약해주세요.

- 질문/답변 페이지가 처음 렌더링 되면 스크롤을 맨 위로 올리는 로직을 추가했습니다.
- 질문/답변 페이지에만 필요할 거 같아서 둘에만 추가했는데 다른 페이지도 필요할 거 같으면 추가하겠습니다.
---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #122

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.

(이미지 첨부)

---
