### PR TITLE
[Feat] listpage에 사용자 선택창 구현

### DIFF
--- a/src/components/UserModal.jsx
+++ b/src/components/UserModal.jsx
@@ -27,12 +27,10 @@ function UserModal({ onClose, subjects }) {
               <li
                 key={subject.id}
                 onClick={handleUserClick}
-                className="border-grayscale-30 bg-brown-10 hover:bg-brown-20 flex cursor-pointer rounded-lg border px-12 py-8"
+                className="border-grayscale-30 bg-brown-10 hover:bg-brown-20 flex cursor-pointer items-center gap-20 rounded-lg border px-12 py-8"
               >
-                <div className="flex">
-                  <div>{subject.id}</div>
-                  <div>{subject.name}</div>
-                </div>
+                <img className="h-48 w-48 rounded-full" src={subject.profile} />
+                <div className="text-body1">{subject.name}</div>
               </li>
             );
           })}

--- a/src/components/UserModal.jsx
+++ b/src/components/UserModal.jsx
@@ -28,7 +28,7 @@ function UserModal({ onClose, subjects }) {
                 onClick={handleUserClick}
                 className="border-grayscale-30 bg-brown-10 hover:bg-brown-20 flex cursor-pointer items-center gap-20 rounded-lg border px-12 py-8"
               >
-                <img className="h-48 w-48 rounded-full" src={subject.profile} />
+                <img className="size-48 rounded-full" src={subject.profile} />
                 <div className="text-body1">{subject.name}</div>
               </li>
             );

--- a/src/components/UserModal.jsx
+++ b/src/components/UserModal.jsx
@@ -1,0 +1,13 @@
+function UserModal() {
+  return (
+    <div className="tablet:px-78 fixed inset-0 flex items-center justify-center p-24">
+      <div className="absolute inset-0 bg-black opacity-56">
+        <div className="bg-grayscale-10 tablet:min-h-454 tablet:max-w-612 tablet:max-h-454 tablet:px-40 shadow-3pt z-10 min-h-568 w-full min-w-327 flex-col rounded-[24px] p-24">
+          <h1>hello</h1>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default UserModal;

--- a/src/components/UserModal.jsx
+++ b/src/components/UserModal.jsx
@@ -1,10 +1,29 @@
-function UserModal() {
+import Person from "../assets/icons/person.svg?react";
+import Close from "../assets/icons/close.svg?react";
+
+function UserModal({ onClose }) {
+  const numbers = [1, 2, 3, 4, 5];
+
   return (
     <div className="tablet:px-78 fixed inset-0 flex items-center justify-center p-24">
-      <div className="absolute inset-0 bg-black opacity-56">
-        <div className="bg-grayscale-10 tablet:min-h-454 tablet:max-w-612 tablet:max-h-454 tablet:px-40 shadow-3pt z-10 min-h-568 w-full min-w-327 flex-col rounded-[24px] p-24">
-          <h1>hello</h1>
+      <div className="absolute inset-0 bg-black opacity-56" />
+      <div className="bg-grayscale-10 tablet:min-h-454 tablet:max-w-612 tablet:max-h-454 tablet:p-40 shadow-3pt z-10 flex min-h-568 w-full min-w-327 flex-col gap-24 rounded-[24px] p-24">
+        <div className="text-grayscale-60 text-body1 flex items-center justify-between gap-8">
+          <Person className="size-28" />
+          <div className="flex-1">사용자를 선택하세요</div>
+          <button onClick={onClose}>
+            <Close className="size-28 cursor-pointer" />
+          </button>
         </div>
+        <ul className="flex flex-col gap-16">
+          {numbers.map((num) => {
+            return (
+              <li className="border-grayscale-30 bg-brown-10 hover:bg-brown-20 flex cursor-pointer rounded-lg border px-12 py-8">
+                {num}
+              </li>
+            );
+          })}
+        </ul>
       </div>
     </div>
   );

--- a/src/components/UserModal.jsx
+++ b/src/components/UserModal.jsx
@@ -6,7 +6,7 @@ function UserModal({ onClose, subjects }) {
   const navigate = useNavigate();
 
   return (
-    <div className="tablet:px-78 fixed inset-0 flex items-center justify-center p-24">
+    <div className="tablet:px-78 fixed inset-0 z-50 flex items-center justify-center p-24">
       <div className="absolute inset-0 bg-black opacity-56" onClick={onClose} />
       <div className="bg-grayscale-10 tablet:min-h-454 tablet:max-w-612 tablet:max-h-454 tablet:p-40 shadow-3pt z-10 flex min-h-568 w-full min-w-327 flex-col gap-24 rounded-3xl p-24">
         <div className="text-grayscale-60 text-body1 flex items-center justify-between gap-8">

--- a/src/components/UserModal.jsx
+++ b/src/components/UserModal.jsx
@@ -16,7 +16,7 @@ function UserModal({ onClose, subjects }) {
             <Close className="size-28 cursor-pointer" />
           </button>
         </div>
-        <ul className="flex flex-col gap-16 overflow-scroll">
+        <ul className="flex flex-col gap-16 overflow-auto">
           {subjects.map((subject) => {
             const handleUserClick = () => {
               navigate(`/post/${subject.id}/answer`);

--- a/src/components/UserModal.jsx
+++ b/src/components/UserModal.jsx
@@ -1,12 +1,13 @@
 import Person from "../assets/icons/person.svg?react";
 import Close from "../assets/icons/close.svg?react";
 
-function UserModal({ onClose }) {
+function UserModal({ onClose, subjects }) {
   const numbers = [1, 2, 3, 4, 5];
+  console.log(subjects);
 
   return (
     <div className="tablet:px-78 fixed inset-0 flex items-center justify-center p-24">
-      <div className="absolute inset-0 bg-black opacity-56" />
+      <div className="absolute inset-0 bg-black opacity-56" onClick={onClose} />
       <div className="bg-grayscale-10 tablet:min-h-454 tablet:max-w-612 tablet:max-h-454 tablet:p-40 shadow-3pt z-10 flex min-h-568 w-full min-w-327 flex-col gap-24 rounded-[24px] p-24">
         <div className="text-grayscale-60 text-body1 flex items-center justify-between gap-8">
           <Person className="size-28" />

--- a/src/components/UserModal.jsx
+++ b/src/components/UserModal.jsx
@@ -1,9 +1,10 @@
+import { useNavigate } from "react-router";
 import Person from "../assets/icons/person.svg?react";
 import Close from "../assets/icons/close.svg?react";
 
 function UserModal({ onClose, subjects }) {
-  const numbers = [1, 2, 3, 4, 5];
   console.log(subjects);
+  const navigate = useNavigate();
 
   return (
     <div className="tablet:px-78 fixed inset-0 flex items-center justify-center p-24">
@@ -16,11 +17,22 @@ function UserModal({ onClose, subjects }) {
             <Close className="size-28 cursor-pointer" />
           </button>
         </div>
-        <ul className="flex flex-col gap-16">
-          {numbers.map((num) => {
+        <ul className="flex flex-col gap-16 overflow-scroll">
+          {subjects.map((subject) => {
+            const handleUserClick = () => {
+              navigate(`/post/${subject.id}/answer`);
+            };
+
             return (
-              <li className="border-grayscale-30 bg-brown-10 hover:bg-brown-20 flex cursor-pointer rounded-lg border px-12 py-8">
-                {num}
+              <li
+                key={subject.id}
+                onClick={handleUserClick}
+                className="border-grayscale-30 bg-brown-10 hover:bg-brown-20 flex cursor-pointer rounded-lg border px-12 py-8"
+              >
+                <div className="flex">
+                  <div>{subject.id}</div>
+                  <div>{subject.name}</div>
+                </div>
               </li>
             );
           })}

--- a/src/components/UserModal.jsx
+++ b/src/components/UserModal.jsx
@@ -3,13 +3,12 @@ import Person from "../assets/icons/person.svg?react";
 import Close from "../assets/icons/close.svg?react";
 
 function UserModal({ onClose, subjects }) {
-  console.log(subjects);
   const navigate = useNavigate();
 
   return (
     <div className="tablet:px-78 fixed inset-0 flex items-center justify-center p-24">
       <div className="absolute inset-0 bg-black opacity-56" onClick={onClose} />
-      <div className="bg-grayscale-10 tablet:min-h-454 tablet:max-w-612 tablet:max-h-454 tablet:p-40 shadow-3pt z-10 flex min-h-568 w-full min-w-327 flex-col gap-24 rounded-[24px] p-24">
+      <div className="bg-grayscale-10 tablet:min-h-454 tablet:max-w-612 tablet:max-h-454 tablet:p-40 shadow-3pt z-10 flex min-h-568 w-full min-w-327 flex-col gap-24 rounded-3xl p-24">
         <div className="text-grayscale-60 text-body1 flex items-center justify-between gap-8">
           <Person className="size-28" />
           <div className="flex-1">사용자를 선택하세요</div>

--- a/src/pages/AnswerPage.jsx
+++ b/src/pages/AnswerPage.jsx
@@ -43,16 +43,15 @@ const AnswerPage = () => {
   const { ref } = useInfiniteScroll({ callback: getMoreData, isMoreQuestion });
 
   const handleDelete = async () => {
-    const subjects = JSON.parse(localStorage.getItem("subjects") || "[]");
-    const updatedSubjects = subjects.filter(
-      (subject) => String(subject.id) !== String(id),
-    );
-    localStorage.setItem("subjects", JSON.stringify(updatedSubjects));
     if (isDeleting) return;
     setIsDeleting(true);
     try {
       await deleteSubject({ subjectId: id });
-      localStorage.removeItem("subject");
+      const subjects = JSON.parse(localStorage.getItem("subjects") || "[]");
+      const updatedSubjects = subjects.filter(
+        (subject) => String(subject.id) !== String(id),
+      );
+      localStorage.setItem("subjects", JSON.stringify(updatedSubjects));
       navigate("/list");
     } catch {
       alert("삭제를 실패했습니다.");

--- a/src/pages/AnswerPage.jsx
+++ b/src/pages/AnswerPage.jsx
@@ -43,6 +43,11 @@ const AnswerPage = () => {
   const { ref } = useInfiniteScroll({ callback: getMoreData, isMoreQuestion });
 
   const handleDelete = async () => {
+    const subjects = JSON.parse(localStorage.getItem("subjects") || "[]");
+    const updatedSubjects = subjects.filter(
+      (subject) => String(subject.id) !== String(id),
+    );
+    localStorage.setItem("subjects", JSON.stringify(updatedSubjects));
     if (isDeleting) return;
     setIsDeleting(true);
     try {

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -40,8 +40,12 @@ function ListPage() {
     const data = localStorage.getItem("subjects");
     if (data) {
       const subjects = JSON.parse(data);
-      setSubjects(subjects);
-      setIsModalOpen(true);
+      if (subjects.length === 0) {
+        navigate("/");
+      } else {
+        setSubjects(subjects);
+        setIsModalOpen(true);
+      }
     } else {
       navigate("/");
     }

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -36,16 +36,6 @@ function ListPage() {
     { label: "이름순", value: "name", click: handleNameClick },
   ];
 
-  // const handleButtonClick = () => {
-  //   const data = localStorage.getItem("selectedSubject");
-  //   if (!data) {
-  //     navigate("/");
-  //     return;
-  //   }
-  //   const { id } = JSON.parse(data);
-  //   id ? navigate(`/post/${id}/answer`) : navigate("/");
-  // };
-
   const handleButtonClick = () => {
     const data = localStorage.getItem("subjects");
     if (data) {

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -40,15 +40,13 @@ function ListPage() {
     const data = localStorage.getItem("subjects");
     if (data) {
       const subjects = JSON.parse(data);
-      if (subjects.length === 0) {
-        navigate("/");
-      } else {
+      if (subjects.length !== 0) {
         setSubjects(subjects);
         setIsModalOpen(true);
+        return;
       }
-    } else {
-      navigate("/");
     }
+    navigate("/");
   };
 
   const handleResize = useCallback(() => {

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -18,9 +18,9 @@ function ListPage() {
   const [itemsPerPage, setItemsPerPage] = useState(1);
   const [currentPage, setCurrentPage] = useState(1);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [subjects, setSubjects] = useState([]);
 
   const handleClose = () => setIsModalOpen(false);
-  const handleOpen = () => setIsModalOpen(true);
 
   const handleLatestClick = () => {
     setSort("createdAt");
@@ -47,13 +47,14 @@ function ListPage() {
   // };
 
   const handleButtonClick = () => {
-    const data = localStorage.getItem("selectedSubject");
-    if (!data) {
+    const data = localStorage.getItem("subjects");
+    if (data) {
+      const subjects = JSON.parse(data);
+      setSubjects(subjects);
+      setIsModalOpen(true);
+    } else {
       navigate("/");
-      return;
     }
-    const { id } = JSON.parse(data);
-    id ? setIsModalOpen(true) : navigate("/");
   };
 
   const handleResize = useCallback(() => {
@@ -86,7 +87,7 @@ function ListPage() {
           답변하러 가기
           <Arrow className="text-brown-40 size-18" />
         </Button>
-        {isModalOpen && <UserModal onClose={handleClose} />}
+        {isModalOpen && <UserModal onClose={handleClose} subjects={subjects} />}
       </div>
       <div className="tablet:gap-32 tablet:px-50 flex flex-col gap-20 px-24">
         <div className="tablet:flex-col tablet:gap-20 flex items-center justify-between">

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -18,6 +18,10 @@ function ListPage() {
   const [itemsPerPage, setItemsPerPage] = useState(1);
   const [currentPage, setCurrentPage] = useState(1);
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleClose = () => setIsModalOpen(false);
+  const handleOpen = () => setIsModalOpen(true);
+
   const handleLatestClick = () => {
     setSort("createdAt");
     setCurrentPage(1);
@@ -82,7 +86,7 @@ function ListPage() {
           답변하러 가기
           <Arrow className="text-brown-40 size-18" />
         </Button>
-        {isModalOpen && <UserModal />}
+        {isModalOpen && <UserModal onClose={handleClose} />}
       </div>
       <div className="tablet:gap-32 tablet:px-50 flex flex-col gap-20 px-24">
         <div className="tablet:flex-col tablet:gap-20 flex items-center justify-between">

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -7,6 +7,7 @@ import Button from "../components/Button";
 import UserList from "../components/UserList";
 import DropdownTrigger from "../components/DropdownTrigger";
 import Pagenation from "../components/Pagenation";
+import UserModal from "../components/UserModal";
 
 function ListPage() {
   const navigate = useNavigate();
@@ -16,6 +17,7 @@ function ListPage() {
   const [totalPages, setTotalPages] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(1);
   const [currentPage, setCurrentPage] = useState(1);
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const handleLatestClick = () => {
     setSort("createdAt");
     setCurrentPage(1);
@@ -30,6 +32,16 @@ function ListPage() {
     { label: "이름순", value: "name", click: handleNameClick },
   ];
 
+  // const handleButtonClick = () => {
+  //   const data = localStorage.getItem("selectedSubject");
+  //   if (!data) {
+  //     navigate("/");
+  //     return;
+  //   }
+  //   const { id } = JSON.parse(data);
+  //   id ? navigate(`/post/${id}/answer`) : navigate("/");
+  // };
+
   const handleButtonClick = () => {
     const data = localStorage.getItem("selectedSubject");
     if (!data) {
@@ -37,7 +49,7 @@ function ListPage() {
       return;
     }
     const { id } = JSON.parse(data);
-    id ? navigate(`/post/${id}/answer`) : navigate("/");
+    id ? setIsModalOpen(true) : navigate("/");
   };
 
   const handleResize = useCallback(() => {
@@ -70,6 +82,7 @@ function ListPage() {
           답변하러 가기
           <Arrow className="text-brown-40 size-18" />
         </Button>
+        {isModalOpen && <UserModal />}
       </div>
       <div className="tablet:gap-32 tablet:px-50 flex flex-col gap-20 px-24">
         <div className="tablet:flex-col tablet:gap-20 flex items-center justify-between">

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -17,7 +17,11 @@ const MainPage = () => {
     try {
       const response = await createSubject({ name });
       const subjectId = response.id;
-      const newSubject = { id: subjectId, name: response.name };
+      const newSubject = {
+        id: subjectId,
+        name: response.name,
+        profile: response.imageSource,
+      };
       const subjects = JSON.parse(localStorage.getItem("subjects") || "[]");
       subjects.unshift(newSubject);
       localStorage.setItem("subjects", JSON.stringify(subjects));

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -19,7 +19,7 @@ const MainPage = () => {
       const subjectId = response.id;
       const newSubject = { id: subjectId, name: response.name };
       const subjects = JSON.parse(localStorage.getItem("subjects") || "[]");
-      subjects.push(newSubject);
+      subjects.unshift(newSubject);
       localStorage.setItem("subjects", JSON.stringify(subjects));
       localStorage.setItem("selectedSubject", JSON.stringify(newSubject));
 


### PR DESCRIPTION
## 📝 PR 내용 요약

> 어떤 작업을 했는지 간단히 요약해주세요.

- mainPage에서 id, name, profile 넘겨받기
- listPage에서 userModal로 로컬 데이터 넘겨주기
- userModal 컴포넌트 생성, 사용자 클릭 시 답변하기 페이지로 이동

- ** mainpage에서 넘겨 받은 질문 갯수는 0으로 저장됩니다. 질문이 추가될 때 업데이트 된 갯수를 받아오려면 user 정보를 계속 새로 호출해야할 것 같아 프로필, 이름만으로 구성하였습니다. 
- ** 답변하기에서 프로필을 삭제했을 때 localStorage의 subjects에 반영될 수 있도록 AnswerPage handleDelete 부분에 코드를 추가하였습니다. 수정해도 기존 코드랑 문제가 없을지 확인 부탁드립니다!

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #121

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.

![image](https://github.com/user-attachments/assets/c4177818-0dc4-4156-9843-7527a79597bf)



---

