### PR TITLE
Bug/129 좋아요, 싫어요 카운트 중복 업데이트 이슈

### DIFF
--- a/src/components/Reaction.jsx
+++ b/src/components/Reaction.jsx
@@ -19,18 +19,26 @@ const Reaction = ({ question }) => {
 
   const handleLike = async () => {
     if (reactionType) return;
-    await postReaction({ id: question.id, type: "like" });
-    setLikeCounts((prev) => prev + 1);
     setReactionType("LIKE");
+    setLikeCounts((prev) => prev + 1);
     localStorage.setItem(storageKey, "LIKE");
+    try {
+      await postReaction({ id: question.id, type: "like" });
+    } catch (error) {
+      console.error("좋아요 요청 실패:", error);
+    }
   };
 
   const handleDislike = async () => {
     if (reactionType) return;
-    await postReaction({ id: question.id, type: "dislike" });
-    setDislikeCounts((prev) => prev + 1);
     setReactionType("DISLIKE");
+    setDislikeCounts((prev) => prev + 1);
     localStorage.setItem(storageKey, "DISLIKE");
+    try {
+      await postReaction({ id: question.id, type: "dislike" });
+    } catch (error) {
+      console.error("싫어요 요청 실패:", error);
+    }
   };
 
   return (

--- a/src/components/Reaction.jsx
+++ b/src/components/Reaction.jsx
@@ -21,11 +21,13 @@ const Reaction = ({ question }) => {
     if (reactionType) return;
     setReactionType("LIKE");
     setLikeCounts((prev) => prev + 1);
-    localStorage.setItem(storageKey, "LIKE");
     try {
       await postReaction({ id: question.id, type: "like" });
+      localStorage.setItem(storageKey, "LIKE");
     } catch (error) {
       console.error("좋아요 요청 실패:", error);
+      setReactionType("");
+      setLikeCounts((prev) => prev - 1);
     }
   };
 
@@ -33,11 +35,14 @@ const Reaction = ({ question }) => {
     if (reactionType) return;
     setReactionType("DISLIKE");
     setDislikeCounts((prev) => prev + 1);
-    localStorage.setItem(storageKey, "DISLIKE");
+
     try {
       await postReaction({ id: question.id, type: "dislike" });
+      localStorage.setItem(storageKey, "DISLIKE");
     } catch (error) {
       console.error("싫어요 요청 실패:", error);
+      setReactionType("");
+      setDislikeCounts((prev) => prev - 1);
     }
   };
 


### PR DESCRIPTION
## 📝 PR 내용 요약

> 좋아요,싫어요를 네트워크 3g상태로 눌렀을 때 카운트수가 로딩되는 동안 중첩되어 눌리는 현상
- +1 되는 코드와 타입지정해주는 코드를 위치 변경
- 즉시 타입으로 설정하는 것으로 해결하였습니다.

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #129 

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
![image](https://github.com/user-attachments/assets/941720d8-55ff-47eb-bed6-59a12379e5a3)

(이미지 첨부)

---
