### PR TITLE
Bug/134-삭제된-subject의-feed-page에-접근

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import MainPage from "./pages/MainPage";
 import ListPage from "./pages/ListPage";
 import QuestionPage from "./pages/QuestionPage";
 import AnswerPage from "./pages/AnswerPage";
+import NotFoundPage from "./pages/NotFoundPage";
 
 function App() {
   return (
@@ -13,6 +14,7 @@ function App() {
         <Route path="/list" element={<ListPage />} />
         <Route path="/post/:id" element={<QuestionPage />} />
         <Route path="/post/:id/answer" element={<AnswerPage />} />
+        <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/hooks/useSubject.js
+++ b/src/hooks/useSubject.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { getSubject } from "../api/subjects";
+import { useNavigate } from "react-router";
 
 const useSubject = (id) => {
   const [subject, setSubject] = useState({
@@ -8,20 +9,27 @@ const useSubject = (id) => {
     isSubject: false,
   });
   const [questionCount, setQuestionCount] = useState(0);
+  const navigate = useNavigate();
   useEffect(() => {
     const getSubjectData = async () => {
-      const { name, imageSource, questionCount } = await getSubject({
-        subjectId: id,
-      });
-      setSubject({
-        name,
-        imageSource,
-        isSubject: true,
-      });
-      setQuestionCount(questionCount);
+      try {
+        const { name, imageSource, questionCount } = await getSubject({
+          subjectId: id,
+        });
+        setSubject({
+          name,
+          imageSource,
+          isSubject: true,
+        });
+        setQuestionCount(questionCount);
+      } catch (error) {
+        if (error.status === 404) {
+          navigate("/NotFoundPage");
+        }
+      }
     };
     getSubjectData();
-  }, [id]);
+  }, [id, navigate]);
   return { subject, questionCount, setQuestionCount };
 };
 export default useSubject;

--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -13,7 +13,7 @@ const NotFoundPage = () => {
 
         <div className="flex flex-col items-center justify-center">
           <p className="tablet:text-h1 text-h2 text-grayscale-60 font-bold">
-            404 - 페이지를 찾을 수 없어요
+            페이지를 찾을 수 없어요
           </p>
           <p className="text-grayscale-40 tablet:text-body1 text-body2 mt-4">
             존재하지 않는 경로로 이동하셨습니다.

--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -1,0 +1,32 @@
+import { Link } from "react-router";
+import Logo from "../assets/images/logo.png";
+import Button from "../components/Button";
+import Arrow from "../assets/icons/arrow.svg?react";
+
+const NotFoundPage = () => {
+  return (
+    <>
+      <div className="bg-grayscale-20 flex h-screen flex-col items-center justify-center gap-72 bg-[url('./assets/images/main-bg.png')] bg-[length:100%_auto] bg-bottom bg-no-repeat">
+        <Link to="/">
+          <img src={Logo} alt="Logo" className="tablet:w-456 w-248" />
+        </Link>
+
+        <div className="flex flex-col items-center justify-center">
+          <p className="tablet:text-h1 text-h2 text-grayscale-60 font-bold">
+            404 - 페이지를 찾을 수 없어요
+          </p>
+          <p className="text-grayscale-40 tablet:text-body1 text-body2 mt-4">
+            존재하지 않는 경로로 이동하셨습니다.
+          </p>
+        </div>
+        <Link to="/list">
+          <Button type="empty" className="tablet:text-16 text-14">
+            질문하러 가기
+            <Arrow className="text-brown-40 size-20" />
+          </Button>
+        </Link>
+      </div>
+    </>
+  );
+};
+export default NotFoundPage;


### PR DESCRIPTION
존재하지 않는 경로나 질문/답변 페이지 처음 사용자 데이터를 못 받아 올 경우 NotFoundPage로 이동합니다.

## 📝 PR 내용 요약

> 어떤 작업을 했는지 간단히 요약해주세요.

- NotFoundPage를 만들어 존재하지 않는 경로로 이동하면 나오게 했습니다.
- 질문 응답 페이지로 이동했을 때 유저의 프로필을 받아오는 부분에서 404응답을 받으면 이동하게 했습니다.
- 페이지 디자인 대충 간단하게 했는데 이쁘게 만들어 주시면 감사하겠습니다.

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #134

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
![화면 캡처 2025-04-27 231833](https://github.com/user-attachments/assets/f4ee3f17-4c88-43dc-870c-c956b9fd43df)
![화면 캡처 2025-04-27 231822](https://github.com/user-attachments/assets/4b7cf628-81e7-4b33-8891-db98e9c1b6c5)

(이미지 첨부)

---
