### PR TITLE
Bug/155-질문을-생성했을-때-questioncount가-바뀌면서-처음-질문을-다시-받아옴

### DIFF
--- a/src/hooks/useInitialQuestion.js
+++ b/src/hooks/useInitialQuestion.js
@@ -9,20 +9,21 @@ const useInitialQuestion = ({
   setIsMoreQuestion,
 }) => {
   const [isInitialLoading, setIsInitialLoading] = useState(false);
+  const isCount = !!questionCount;
   useEffect(() => {
-    if (!questionCount) return;
+    if (!isCount) return;
     const getInitialData = async () => {
       setIsInitialLoading(true);
-      const { results } = await getQuestionList({ subjectId: id });
+      const { results, count } = await getQuestionList({ subjectId: id });
       setQuestionList(results);
       setOffset(results.length);
-      if (results.length < questionCount) {
+      if (results.length < count) {
         setIsMoreQuestion(true);
       }
       setIsInitialLoading(false);
     };
     getInitialData();
-  }, [id, questionCount, setQuestionList, setOffset, setIsMoreQuestion]);
+  }, [id, isCount, setQuestionList, setOffset, setIsMoreQuestion]);
   return { isInitialLoading };
 };
 export default useInitialQuestion;


### PR DESCRIPTION
## 📝 PR 내용 요약

> 어떤 작업을 했는지 간단히 요약해주세요.

- 초기 데이터를 불러오는 과정에서 questionCount가 바뀌어도 데이터를 안불러오게 했습니다.

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #155

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.

(이미지 첨부)

---
