### PR TITLE
fix/165 최상위 태그 height 스타일 수정

### DIFF
--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -70,7 +70,7 @@ function ListPage() {
   }, [handleResize]);
 
   return (
-    <div className="bg-grayscale-20 h-screen">
+    <div className="bg-grayscale-20 min-h-screen">
       <div className="tablet:flex-row tablet:justify-between flex flex-col items-center justify-center gap-24 px-50 pt-40 pb-60">
         <Link to="/">
           <img className="h-57 w-146" src={logo}></img>


### PR DESCRIPTION
## 📝 PR 내용 요약

- h-screen 때문에 배경 크기가 고정되어 일부 환경에서 하단에 배경색이 적용되지 않는 문제를 수정하였습니다.
- 가능하다면 rebase로 merge 할 예정입니다

## 🧩 관련 이슈

- Close #165 

## 📸 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/76506a60-37f1-442c-adcb-d11d2f2ea170)
![image](https://github.com/user-attachments/assets/b4112562-6bf7-49a0-9b05-86a110bca3cd)

