### PR TITLE
fix/171 moblie 환경에서 FeedCard 프로필 이미지 비율 뭉개짐 해결

### DIFF
--- a/src/components/feedCard/FeedCardAnswer.jsx
+++ b/src/components/feedCard/FeedCardAnswer.jsx
@@ -7,7 +7,7 @@ function FeedCardAnswer({ state, subject, answer, children }) {
         className="tablet:size-48 bg-grayscale-30 size-32 rounded-full bg-cover bg-center"
         style={{ backgroundImage: `url(${subject.imageSource})` }}
       />
-      <section className="grow">
+      <section className="flex-1">
         <div className="mb-4 flex flex-row items-center gap-8">
           <div className="text-caption1 tablet:text-body2">{subject.name}</div>
           <div className="text-caption1 text-grayscale-40 font-medium">


### PR DESCRIPTION
## 📝 PR 내용 요약

- 일부 환경에서 답변의 프로필 이미지 비율이 깨지는 현상 해결
- flex-grow만 존재하고 flex-shrink의 부재 때문

## 🧩 관련 이슈

- Close #171 

## 📸 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/1a8641f8-0f96-4dde-9296-8c354e70b56f)
