### PR TITLE
fix/185 InputTextarea 내용이 공백일 때 Button 비활성화

### DIFF
--- a/src/components/feedCard/FeedCardAnswerInput.jsx
+++ b/src/components/feedCard/FeedCardAnswerInput.jsx
@@ -37,7 +37,7 @@ function FeedCardAnswerInput({ setState, questionId, answer, setAnswer }) {
   };
 
   const handleChange = () => {
-    setDisabled(content.current.value ? false : true);
+    setDisabled(content.current.value.trim() ? false : true);
   };
 
   return (


### PR DESCRIPTION
## 📝 PR 내용 요약

- FeedCard의 답변 내용이 공백일 때 Button을 비활성화


## 🧩 관련 이슈

- Close #185 

## 📸 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/f55f294a-7f3a-4d74-8a97-6eaf26d9b7fe)

