### PR TITLE
fix/183 InputField 내용이 공백일 시 Button 비활성화

### DIFF
--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -53,7 +53,7 @@ const MainPage = () => {
         <Button
           className="tablet:w-336"
           type="fill"
-          disabled={name.length === 0 || name.length > 15}
+          disabled={name.trim().length === 0 || name.trim().length > 15}
           onClick={handleQuestionClick}
         >
           질문 받기


### PR DESCRIPTION
## 📝 PR 내용 요약

- Input이 공백 문자로만 채워져 있을 시 버튼이 비활성화 됨

## 🧩 관련 이슈

- Close #183 

## 📸 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/1006a028-e5c8-4b76-8178-cadd7db1ece9)

